### PR TITLE
[Added]: get api currency exchange from Bank of Thailand

### DIFF
--- a/thai_tax/custom/currency_exchange_bot_api.py
+++ b/thai_tax/custom/currency_exchange_bot_api.py
@@ -1,0 +1,73 @@
+import frappe # type: ignore
+from frappe import _ # type: ignore
+import http.client
+from datetime import datetime, timedelta
+import json
+
+
+@frappe.whitelist(allow_guest=True)
+def get_api_currency_exchange(from_currency, to_currency, transaction_date):
+
+    # Convert the transaction_date string to a datetime object
+    trans_start_date = datetime.strptime(transaction_date, "%Y-%m-%d")
+    trans_start_date = trans_start_date - timedelta(days=5)
+
+    trans_start_date = trans_start_date.strftime("%Y-%m-%d")
+
+    trans_end_date = datetime.strptime(transaction_date, "%Y-%m-%d")
+    trans_end_date = trans_end_date.strftime("%Y-%m-%d")
+
+    # Params to BOT API
+    start_date = trans_start_date
+    end_date = trans_end_date
+    currency = from_currency
+
+    site_config = frappe.get_site_config()
+    client_id = site_config.get("bot_client_id")
+    conn = http.client.HTTPSConnection("apigw1.bot.or.th")
+    headers = {
+        'X-IBM-Client-Id': client_id,
+        'accept': "application/json"
+    }
+
+    # Properly formatted URL with dynamic date parameters
+    url_path = f"/bot/public/Stat-ExchangeRate/v2/DAILY_AVG_EXG_RATE/?start_period={start_date}&end_period={end_date}&currency={currency}"
+    conn.request("GET", url_path, headers=headers)
+
+    # Respose
+    res = conn.getresponse()
+    data = res.read()
+    result = data.decode("utf-8")
+
+    # To Json
+    parsed_result = json.loads(result)
+
+    rates = 0
+    # Check if 'data_detail' exists and has items
+    if 'data_detail' in parsed_result['result']['data'] and parsed_result['result']['data']['data_detail']:
+        data_detail = parsed_result['result']['data']['data_detail']
+
+        # Sort data by the 'period' field if not empty
+        if data_detail:
+            sorted_data = sorted(data_detail, key=lambda x: datetime.strptime(x['period'], '%Y-%m-%d'))
+
+            # Get the latest period's data (the last element in the sorted list)
+            latest_period_data = sorted_data[-1]
+            rates = latest_period_data['selling']
+            rates = float(rates)
+        else:
+            rates = 0
+    else:
+        rates = 0
+
+    # Creating the response dictionary
+    response_data = {
+        'amount': 1.0,
+        'from_currency': from_currency,
+        'date': transaction_date,
+        'rates': {to_currency: rates}  # Assume rate is static for example
+    }
+    print('response_data', response_data)
+    # Setting the response directly to avoid Frappe's automatic "data" wrapping
+    frappe.local.response.http_status_code = 200  # Setting HTTP status code
+    frappe.local.response.message = response_data 

--- a/thai_tax/fixtures/property_setter.json
+++ b/thai_tax/fixtures/property_setter.json
@@ -1,0 +1,18 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Currency Exchange Settings",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "service_provider",
+  "is_system_generated": 0,
+  "modified": "2024-10-29 12:42:11.496071",
+  "module": "Thai Tax",
+  "name": "Currency Exchange Settings-service_provider-options",
+  "property": "options",
+  "property_type": "Select",
+  "row_name": null,
+  "value": "frankfurter.app\nexchangerate.host\nCustom\nBank of Thailand"
+ }
+]

--- a/thai_tax/hooks.py
+++ b/thai_tax/hooks.py
@@ -8,6 +8,21 @@ app_email = "kittiu@gmail.com"
 app_license = "MIT"
 required_apps = ["erpnext"]
 
+fixtures = [
+    {
+		"doctype": "Property Setter",
+		"filters": [
+			[
+				"name",
+				"in",
+				(
+					"Currency Exchange Settings-service_provider-options",
+				),
+			]
+		],
+	},
+]
+
 # Includes in <head>
 # ------------------
 
@@ -40,6 +55,7 @@ doctype_js = {
 	"Sales Tax Invoice": "public/js/sales_tax_invoice.js",
 	"Withholding Tax Cert": "public/js/withholding_tax_cert.js",
 	"Address": "public/js/address.js",
+    "Currency Exchange Settings": "public/js/currency_exchange_settings.js",
 }
 
 

--- a/thai_tax/public/js/currency_exchange_settings.js
+++ b/thai_tax/public/js/currency_exchange_settings.js
@@ -1,0 +1,64 @@
+frappe.ui.form.on('Currency Exchange Settings', {
+    refresh(frm) {
+        if (frm.doc.service_provider === 'Bank of Thailand') {
+            frm.toggle_display('use_http', false);
+        }
+    },
+
+    set_table_parameters: function (frm) {
+        // Clear existing rows
+        frm.clear_table('req_params');
+
+        // Example data to add
+        const set_parameters = [
+            { key: 'from_currency', value: '{from_currency}' },
+            { key: 'to_currency', value: '{to_currency}' },
+            { key: 'transaction_date', value: '{transaction_date}' }
+        ];
+
+        // Add new rows
+        set_parameters.forEach(data => {
+            const child = frm.add_child('req_params');
+            frappe.model.set_value(child.doctype, child.name, 'key', data.key);
+            frappe.model.set_value(child.doctype, child.name, 'value', data.value);
+        });
+        // Refresh the child table to show changes
+        frm.refresh_field('req_params');
+    },
+    set_table_result_key: function (frm) {
+        // Clear existing rows
+        frm.clear_table('result_key');
+
+        // Example data to add
+        const set_result_key = [
+            { key: 'message' },
+            { key: 'rates' },
+            { key: '{to_currency}' }
+        ];
+
+        // Add new rows
+        set_result_key.forEach(data => {
+            const child = frm.add_child('result_key');
+            frappe.model.set_value(child.doctype, child.name, 'key', data.key);
+        });
+
+        // Refresh the child table to show changes
+        frm.refresh_field('result_key');
+    },
+
+    service_provider: function (frm) {
+        if (frm.doc.service_provider === 'Bank of Thailand') {
+            const base_url = window.location.origin
+            frm.set_value("api_endpoint", `${base_url}/api/v2/method/thai_tax.custom.currency_exchange_bot_api.get_api_currency_exchange`);
+            frm.set_value("url", null)
+            frm.toggle_display('use_http', false);
+
+            frm.events.set_table_parameters(frm);
+            frm.events.set_table_result_key(frm);
+
+
+        } else {
+            frm.toggle_display('use_http', true);
+        }
+    }
+});


### PR DESCRIPTION
อธิบายการทำงาน

![ce1](https://github.com/user-attachments/assets/f8a40dbc-3854-40e9-b8f2-c1713c66dd65)
ตามรูป 
1. จะเพิ่มตัวเลือก Bank of Thailand ลงไปใน Select **Service Provider** แล้วถ้าหากเลือกเป็น Bank of Thailand จะ Set ข้อมูลที่ใช้สำหรับเรียก API ที่สร้างมาโดยเฉพาะ
2. ถ้าเลือกเป็น Bank of Thailand จะ Set ข้อมูล 2 ตารางนี้ให้พร้อมใช้งาน

การดึง API มาต้องใช้ client_id ไปสร้างเก็บไว้ที่ site_config.json (เดี๋ยว client_id  ผมส่งให้ส่วนตัวนะครับ) แล้วมาเรียกใช้ในหน้านี้
![Screenshot_2](https://github.com/user-attachments/assets/8f607ef4-e52c-4e90-a867-5107942e4f16)

![Screenshot_1](https://github.com/user-attachments/assets/8e103e69-44ad-4dbc-be76-60676075405e)

- เพิ่ม Option Bank of Thailand ลงไปใน Select export ออกมาไว้ที Fixture แล้ว
![image](https://github.com/user-attachments/assets/d07f618e-5212-43e3-83a4-4b4698c790c7)

